### PR TITLE
do not fail the test when removing kubeadmin from sub-admin fails

### DIFF
--- a/client/canary/scripts/subscriptionAdmin/test.sh
+++ b/client/canary/scripts/subscriptionAdmin/test.sh
@@ -174,8 +174,6 @@ $KUBECTL_CMD patch clusterrolebinding open-cluster-management:subscription-admin
     -p="[{\"op\": \"remove\", \"path\": \"/subjects/$SUB_ADMIN_INDEX\", \"value\": $SUBJECT}]"
 if [ $? -ne 0 ]; then
     echo "failed to remove kubeadmin user from open-cluster-management:subscription-admin clusterrolebinding"
-    echo "E2E CANARY TEST - EXIT WITH ERROR"
-    exit 1
 fi
 
 # Delete test namespaces


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/stolostron/backlog/issues/22502

Do not fail the canary test when the test script fails to remove kubeadmin from the sub-admin cluster role binding. It is not important as long as the actual tests succeed.